### PR TITLE
Now a python version is required for alpine, themekit currently support v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine
 RUN apk update
 
 # https://shopify.github.io/themekit/
-RUN apk add --no-cache python ca-certificates curl && \
+RUN apk add --no-cache python2 ca-certificates curl && \
     curl -s https://shopify.github.io/themekit/scripts/install.py | python && \
     apk del curl
 


### PR DESCRIPTION
Moved to python2 according to [this discussion](https://stackoverflow.com/questions/62169568/docker-alpine-linux-python-missing)